### PR TITLE
Updated beacon-v2 submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lsaai"]
 	path = lsaai
 	url = git@github.com:GenomicDataInfrastructure/starter-kit-lsaai.git
+[submodule "beacon-v2"]
+	path = beacon-v2
+	url = git@github.com:EGA-archive/beacon2-ri-api.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "storage-and-interfaces"]
 	path = storage-and-interfaces
 	url = git@github.com:GenomicDataInfrastructure/starter-kit-storage-and-interfaces.git
-[submodule "beacon-v2"]
-	path = beacon-v2
-	url = git@github.com:GenomicDataInfrastructure/starter-kit-beacon2-ri-api.git
 [submodule "rems"]
 	path = rems
 	url = git@github.com:GenomicDataInfrastructure/starter-kit-rems.git


### PR DESCRIPTION
The beacon-v2 submodule was still pointing to the deprecated beacon-v2 repository.