### PR TITLE
updating beacon-v2 to new beacon pi url and HEAD to 6c541ab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = git@github.com:GenomicDataInfrastructure/starter-kit-lsaai.git
 [submodule "beacon-v2"]
 	path = beacon-v2
-	url = git@github.com:EGA-archive/beacon2-ri-api.git
+	url = git@github.com:EGA-archive/beacon2-pi-api.git
 [submodule "userportal"]
 	path = userportal
 	url = git@github.com:GenomicDataInfrastructure/gdi-userportal-deployment.git


### PR DESCRIPTION
Updating beacon-v2 to the beacon PI repo for starter kit.